### PR TITLE
Private Waystones & Lootable Return Scrolls

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
@@ -30,6 +30,8 @@ public class WaystoneConfig {
 
     public boolean interDimension;
 
+    public boolean privateWaystones;
+
     public boolean creativeModeOnly;
     public boolean setSpawnPoint;
 
@@ -143,6 +145,12 @@ public class WaystoneConfig {
             "If true, the player's spawnpoint will be set to the last activated waystone.");
         interDimension = config
             .getBoolean("interDimension", Categories.general, true, "If true, all waystones work inter-dimensionally.");
+
+        privateWaystones = config.getBoolean(
+            "Private Waystones",
+            Categories.general,
+            false,
+            "If true, only owners can break their own waystones.");
 
         creativeModeOnly = config.getBoolean(
             "creativeModeOnly",
@@ -340,6 +348,7 @@ public class WaystoneConfig {
         config.globalNoCooldown = buf.readBoolean();
         config.waystoneLightLevel = buf.readFloat();
         config.disableWaystoneDrops = buf.readBoolean();
+        config.privateWaystones = buf.readBoolean();
         int sandyPathBlockCount = buf.readInt();
         config.sandyWaystonePathBlocks = new String[sandyPathBlockCount];
         for (int i = 0; i < sandyPathBlockCount; i++) {
@@ -377,6 +386,7 @@ public class WaystoneConfig {
         buf.writeBoolean(globalNoCooldown);
         buf.writeFloat(waystoneLightLevel);
         buf.writeBoolean(disableWaystoneDrops);
+        buf.writeBoolean(privateWaystones);
         String[] sandyBlocks = sandyWaystonePathBlocks != null ? sandyWaystonePathBlocks : new String[0];
         buf.writeInt(sandyBlocks.length);
         for (String sandyPathBlock : sandyBlocks) {

--- a/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
@@ -24,6 +24,7 @@ public class WaystoneConfig {
     public static boolean showCooldownOnWaystone;
 
     public boolean allowReturnScrolls;
+    public boolean lootReturnScrolls;
     public boolean allowWarpStone;
 
     public int warpStoneCooldown;
@@ -97,6 +98,11 @@ public class WaystoneConfig {
 
         allowReturnScrolls = config
             .getBoolean("allowReturnScrolls", Categories.general, true, "If true, return scrolls will be craftable.");
+        lootReturnScrolls = config.getBoolean(
+            "Spawn Return Scrolls as loot",
+            Categories.general,
+            true,
+            "If true, return scrolls will be found in dungeons as loot.");
         allowWarpStone = config
             .getBoolean("allowWarpStone", Categories.general, true, "If true, the warp stone will be craftable.");
 
@@ -344,6 +350,7 @@ public class WaystoneConfig {
         config.xpBlocksPerLevel = buf.readInt();
         config.xpCrossDimCost = buf.readInt();
         config.allowReturnScrolls = buf.readBoolean();
+        config.lootReturnScrolls = buf.readBoolean();
         config.allowWarpStone = buf.readBoolean();
         config.globalNoCooldown = buf.readBoolean();
         config.waystoneLightLevel = buf.readFloat();
@@ -382,6 +389,7 @@ public class WaystoneConfig {
         buf.writeInt(xpBlocksPerLevel);
         buf.writeInt(xpCrossDimCost);
         buf.writeBoolean(allowReturnScrolls);
+        buf.writeBoolean(lootReturnScrolls);
         buf.writeBoolean(allowWarpStone);
         buf.writeBoolean(globalNoCooldown);
         buf.writeFloat(waystoneLightLevel);

--- a/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
@@ -31,7 +31,7 @@ public class WaystoneConfig {
 
     public boolean interDimension;
 
-    public boolean privateWaystones;
+    public boolean invulnerableWaystones;
 
     public boolean creativeModeOnly;
     public boolean setSpawnPoint;
@@ -152,11 +152,11 @@ public class WaystoneConfig {
         interDimension = config
             .getBoolean("interDimension", Categories.general, true, "If true, all waystones work inter-dimensionally.");
 
-        privateWaystones = config.getBoolean(
-            "Private Waystones",
+        invulnerableWaystones = config.getBoolean(
+            "Invulnerable Waystones",
             Categories.general,
             false,
-            "If true, only owners can break their own waystones.");
+            "If true, a waystone is invulnerable to all but the player who named them.");
 
         creativeModeOnly = config.getBoolean(
             "creativeModeOnly",
@@ -355,7 +355,7 @@ public class WaystoneConfig {
         config.globalNoCooldown = buf.readBoolean();
         config.waystoneLightLevel = buf.readFloat();
         config.disableWaystoneDrops = buf.readBoolean();
-        config.privateWaystones = buf.readBoolean();
+        config.invulnerableWaystones = buf.readBoolean();
         int sandyPathBlockCount = buf.readInt();
         config.sandyWaystonePathBlocks = new String[sandyPathBlockCount];
         for (int i = 0; i < sandyPathBlockCount; i++) {
@@ -394,7 +394,7 @@ public class WaystoneConfig {
         buf.writeBoolean(globalNoCooldown);
         buf.writeFloat(waystoneLightLevel);
         buf.writeBoolean(disableWaystoneDrops);
-        buf.writeBoolean(privateWaystones);
+        buf.writeBoolean(invulnerableWaystones);
         String[] sandyBlocks = sandyWaystonePathBlocks != null ? sandyWaystonePathBlocks : new String[0];
         buf.writeInt(sandyBlocks.length);
         for (String sandyPathBlock : sandyBlocks) {

--- a/src/main/java/net/blay09/mods/waystones/Waystones.java
+++ b/src/main/java/net/blay09/mods/waystones/Waystones.java
@@ -11,6 +11,8 @@ import net.blay09.mods.waystones.varinstances.VarInstanceCommon;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.WeightedRandomChestContent;
+import net.minecraftforge.common.ChestGenHooks;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
@@ -239,6 +241,22 @@ public class Waystones {
                     itemWarpStone,
                     'O',
                     Blocks.obsidian));
+        }
+
+        if (config.lootReturnScrolls) {
+            // Item, min, max, weight
+            ChestGenHooks.getInfo(ChestGenHooks.VILLAGE_BLACKSMITH)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 1, 5));
+            ChestGenHooks.getInfo(ChestGenHooks.MINESHAFT_CORRIDOR)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 1, 3));
+            ChestGenHooks.getInfo(ChestGenHooks.DUNGEON_CHEST)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 2, 3));
+            ChestGenHooks.getInfo(ChestGenHooks.PYRAMID_DESERT_CHEST)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 1, 3));
+            ChestGenHooks.getInfo(ChestGenHooks.PYRAMID_JUNGLE_CHEST)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 1, 2));
+            ChestGenHooks.getInfo(ChestGenHooks.STRONGHOLD_LIBRARY)
+                .addItem(new WeightedRandomChestContent(new ItemStack(itemReturnScroll), 1, 1, 2));
         }
     }
 

--- a/src/main/java/net/blay09/mods/waystones/Waystones.java
+++ b/src/main/java/net/blay09/mods/waystones/Waystones.java
@@ -79,6 +79,16 @@ public class Waystones {
         DEBUG_MODE = debugVar != null;
         LOG.info("Debugmode: {}", DEBUG_MODE);
 
+        configuration = new Configuration(event.getSuggestedConfigurationFile());
+        config = new WaystoneConfig();
+        config.reloadLocal(configuration);
+        setConfig(config);
+        varInstanceCommon.preInitHook();
+        WaystoneConfig.setConfig(configuration);
+        if (configuration.hasChanged()) {
+            configuration.save();
+        }
+
         blockWaystone = new BlockWaystone();
         GameRegistry.registerBlock(blockWaystone, ItemBlockWaystone.class, "waystone");
         blockWaystoneSandstone = new BlockWaystone(TileWaystone.VARIANT_SANDSTONE, "waystone_sandstone");
@@ -104,16 +114,6 @@ public class Waystones {
         GameRegistry.registerItem(itemWarpStone, "warpStone");
 
         NetworkHandler.init();
-
-        configuration = new Configuration(event.getSuggestedConfigurationFile());
-        config = new WaystoneConfig();
-        config.reloadLocal(configuration);
-        setConfig(config);
-        varInstanceCommon.preInitHook();
-        WaystoneConfig.setConfig(configuration);
-        if (configuration.hasChanged()) {
-            configuration.save();
-        }
 
         proxy.preInit(event);
     }

--- a/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
+++ b/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
@@ -15,6 +15,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.boss.IBossDisplayData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -122,7 +123,26 @@ public class BlockWaystone extends BlockContainer {
         if (Waystones.getConfig().creativeModeOnly && !player.capabilities.isCreativeMode) {
             return -1f;
         }
+
+        if (Waystones.getConfig().privateWaystones) {
+            TileWaystone tileWaystone = getTileWaystone(world, x, y, z);
+
+            if (tileWaystone != null) {
+                String waystoneOwner = tileWaystone.getWaystoneOwner();
+
+                if (!(waystoneOwner.contentEquals("") || waystoneOwner.contentEquals(
+                    player.getUniqueID()
+                        .toString())))
+                    return -1f;
+            }
+        }
         return super.getPlayerRelativeBlockHardness(player, world, x, y, z);
+    }
+
+    @Override
+    public boolean canEntityDestroy(IBlockAccess world, int x, int y, int z, Entity entity) {
+        if (Waystones.getConfig().privateWaystones && entity instanceof IBossDisplayData) return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
+++ b/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.waystones.block;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 import net.blay09.mods.waystones.WaystoneConfig;
@@ -15,7 +16,6 @@ import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.boss.IBossDisplayData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -51,8 +51,10 @@ public class BlockWaystone extends BlockContainer {
         this.defaultVariant = defaultVariant;
         this.iconName = registryName + "_icon";
         setBlockName(Waystones.MODID + ":" + registryName);
+
         setHardness(5f);
-        setResistance(2000f);
+        setResistance(Waystones.getConfig().privateWaystones ? 6000000.0F : 2000f);
+
         setCreativeTab(CreativeTabs.tabDecorations);
     }
 
@@ -129,10 +131,11 @@ public class BlockWaystone extends BlockContainer {
 
             if (tileWaystone != null) {
                 String waystoneOwner = tileWaystone.getWaystoneOwner();
+                boolean hasOwner = !Objects.equals(waystoneOwner, "");
 
-                if (!(waystoneOwner.contentEquals("") || waystoneOwner.contentEquals(
+                if (hasOwner && !waystoneOwner.contentEquals(
                     player.getUniqueID()
-                        .toString())))
+                        .toString()))
                     return -1f;
             }
         }
@@ -141,7 +144,31 @@ public class BlockWaystone extends BlockContainer {
 
     @Override
     public boolean canEntityDestroy(IBlockAccess world, int x, int y, int z, Entity entity) {
-        if (Waystones.getConfig().privateWaystones && entity instanceof IBossDisplayData) return false;
+        if (Waystones.getConfig().privateWaystones) {
+
+            if (!(entity instanceof EntityPlayer player)) {
+                return false;
+            }
+
+            if (player.capabilities.isCreativeMode) {
+                return true;
+            }
+
+            TileWaystone waystone = getTileWaystone((World) world, x, y, z);
+            if (waystone != null) {
+
+                String ownerId = waystone.getWaystoneOwner();
+                boolean hasOwner = !Objects.equals(ownerId, "");
+
+                if (hasOwner) {
+                    return Objects.equals(
+                        player.getUniqueID()
+                            .toString(),
+                        waystone.getWaystoneOwner());
+                }
+            }
+        }
+
         return true;
     }
 

--- a/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
+++ b/src/main/java/net/blay09/mods/waystones/block/BlockWaystone.java
@@ -53,7 +53,7 @@ public class BlockWaystone extends BlockContainer {
         setBlockName(Waystones.MODID + ":" + registryName);
 
         setHardness(5f);
-        setResistance(Waystones.getConfig().privateWaystones ? 6000000.0F : 2000f);
+        setResistance(Waystones.getConfig().invulnerableWaystones ? 6000000.0F : 2000f);
 
         setCreativeTab(CreativeTabs.tabDecorations);
     }
@@ -126,7 +126,7 @@ public class BlockWaystone extends BlockContainer {
             return -1f;
         }
 
-        if (Waystones.getConfig().privateWaystones) {
+        if (Waystones.getConfig().invulnerableWaystones) {
             TileWaystone tileWaystone = getTileWaystone(world, x, y, z);
 
             if (tileWaystone != null) {
@@ -144,7 +144,7 @@ public class BlockWaystone extends BlockContainer {
 
     @Override
     public boolean canEntityDestroy(IBlockAccess world, int x, int y, int z, Entity entity) {
-        if (Waystones.getConfig().privateWaystones) {
+        if (Waystones.getConfig().invulnerableWaystones) {
 
             if (!(entity instanceof EntityPlayer player)) {
                 return false;

--- a/src/main/java/net/blay09/mods/waystones/block/TileWaystone.java
+++ b/src/main/java/net/blay09/mods/waystones/block/TileWaystone.java
@@ -20,6 +20,7 @@ public class TileWaystone extends TileEntity {
     public static final int VARIANT_MOSSY_STONEBRICK = 6;
 
     private String waystoneName = "";
+    private String waystoneOwner = "";
     private int variant = VARIANT_STONE;
     private boolean forceGlobalOnActivation;
     private static int warpGeneration = 0;
@@ -59,6 +60,7 @@ public class TileWaystone extends TileEntity {
     public void writeToNBT(NBTTagCompound tagCompound) {
         super.writeToNBT(tagCompound);
         tagCompound.setString("WaystoneName", waystoneName);
+        tagCompound.setString("WaystoneOwner", waystoneOwner);
         tagCompound.setInteger("Variant", variant);
         tagCompound.setBoolean("ForceGlobalOnActivation", forceGlobalOnActivation);
     }
@@ -67,6 +69,7 @@ public class TileWaystone extends TileEntity {
     public void readFromNBT(NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         waystoneName = tagCompound.getString("WaystoneName");
+        waystoneOwner = tagCompound.getString("WaystoneOwner");
         if (tagCompound.hasKey("Variant")) {
             setVariant(tagCompound.getInteger("Variant"));
         } else {
@@ -94,6 +97,16 @@ public class TileWaystone extends TileEntity {
 
     public void setWaystoneName(String waystoneName) {
         this.waystoneName = waystoneName;
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        markDirty();
+    }
+
+    public String getWaystoneOwner() {
+        return waystoneOwner;
+    }
+
+    public void setWaystoneOwner(String waystoneOwner) {
+        this.waystoneOwner = waystoneOwner;
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         markDirty();
     }

--- a/src/main/java/net/blay09/mods/waystones/network/handler/HandlerWaystoneName.java
+++ b/src/main/java/net/blay09/mods/waystones/network/handler/HandlerWaystoneName.java
@@ -49,7 +49,7 @@ public class HandlerWaystoneName implements IMessageHandler<MessageWaystoneName,
                     }
                     WaystoneManager.removeServerWaystone(new WaystoneEntry((TileWaystone) tileEntity));
                     ((TileWaystone) tileEntity).setWaystoneName(message.getName());
-                    if (Waystones.getConfig().privateWaystones && !(entityPlayer instanceof FakePlayer))
+                    if (Waystones.getConfig().invulnerableWaystones && !(entityPlayer instanceof FakePlayer))
                         ((TileWaystone) tileEntity).setWaystoneOwner(
                             entityPlayer.getUniqueID()
                                 .toString());

--- a/src/main/java/net/blay09/mods/waystones/network/handler/HandlerWaystoneName.java
+++ b/src/main/java/net/blay09/mods/waystones/network/handler/HandlerWaystoneName.java
@@ -12,6 +12,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.FakePlayer;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -48,6 +49,10 @@ public class HandlerWaystoneName implements IMessageHandler<MessageWaystoneName,
                     }
                     WaystoneManager.removeServerWaystone(new WaystoneEntry((TileWaystone) tileEntity));
                     ((TileWaystone) tileEntity).setWaystoneName(message.getName());
+                    if (Waystones.getConfig().privateWaystones && !(entityPlayer instanceof FakePlayer))
+                        ((TileWaystone) tileEntity).setWaystoneOwner(
+                            entityPlayer.getUniqueID()
+                                .toString());
                     if (message.isGlobal() /* && ctx.getServerHandler().playerEntity.capabilities.isCreativeMode */) {
                         WaystoneManager.addServerWaystone(new WaystoneEntry((TileWaystone) tileEntity));
                         for (EntityPlayer obj : MinecraftServer.getServer()


### PR DESCRIPTION
- Private Waystone Mode
When "Private Waystones" is set to true only owners may pick up their waystones (ownership set to the player who named it).

_Ownerless Waystones (WorldGen or placed by a Fake Player) are not affected by "Private Wastones"._

Additionally, "Private Waystones" are given complete immunity to being destroyed by any Boss Mobs such as Withers and Ender Dragons.

- Lootable Return Scrolls
Adds config to inject Return Scrolls in the loot table.