### PR TITLE
Fix NoClassDefFoundError: net/minecraft/client/resources/I18n on dedicated server

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/network/handler/HandlerDimensionNames.java
+++ b/src/main/java/net/blay09/mods/waystones/network/handler/HandlerDimensionNames.java
@@ -12,7 +12,7 @@ public class HandlerDimensionNames implements IMessageHandler<MessageDimensionNa
     @Override
     public IMessage onMessage(MessageDimensionNames message, MessageContext ctx) {
         for (int i = 0; i < message.getAmount(); i++) {
-            DimensionUtil.setEntry(message.getIds()[i], message.getNames()[i]);
+            DimensionUtil.setEntry(message.getIds()[i], DimensionUtil.localizeDimName(message.getNames()[i]));
         }
         return null;
     }

--- a/src/main/java/net/blay09/mods/waystones/network/message/MessageDimensionNames.java
+++ b/src/main/java/net/blay09/mods/waystones/network/message/MessageDimensionNames.java
@@ -1,6 +1,5 @@
 package net.blay09.mods.waystones.network.message;
 
-import net.blay09.mods.waystones.util.DimensionUtil;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
@@ -25,7 +24,7 @@ public class MessageDimensionNames implements IMessage {
             this.ids[this.amount] = dimId;
             WorldServer world = DimensionManager.getWorld(dimId);
             WorldProvider provider = world != null ? world.provider : DimensionManager.createProviderFor(dimId);
-            this.names[this.amount] = DimensionUtil.localizeDimName(provider.getDimensionName());
+            this.names[this.amount] = provider.getDimensionName();
             this.amount++;
         }
     }


### PR DESCRIPTION
`MessageDimensionNames` was calling `DimensionUtil.localizeDimName()` in its constructor which internally calls `net.minecraft.client.resources.I18n.format()`. That class only exists in the client JAR so any dedicated server would crash with a `NoClassDefFoundError` during player login when this message is built server-side.

The Fix -  send the raw dimension name from the server and move the `localizeDimName()`
call into `HandlerDimensionNames` which runs on the client where `I18n` is available.